### PR TITLE
build: set abp_core to uninstallable

### DIFF
--- a/addons/abp_core/__manifest__.py
+++ b/addons/abp_core/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    'name': 'Able Pack Core Module',
+    'name': '(Deprecated) Able Pack Core Module',
     'category': '',
     'sequence': 23,
     'summary': 'Able Pack Core Module',
@@ -49,7 +49,7 @@
     ],
     'assets': {
     },
-    'installable': True,
+    'installable': False,
     'auto_install': False,
     'application': True,
     'license': 'LGPL-3',


### PR DESCRIPTION
- we will be installing all modules manually instead of installing all at once using this module (abp_core)