### PR TITLE
build: remove dependency to purchase requisition module (2)

### DIFF
--- a/external_addons/bi_order_line_with_sequence_number/report/order_line_inherit_report.xml
+++ b/external_addons/bi_order_line_with_sequence_number/report/order_line_inherit_report.xml
@@ -78,7 +78,8 @@
             </xpath>
         </template>
 
-        <template id="purchase_agreement_report"
+        <!-- # NOT USED -->
+        <!-- <template id="purchase_agreement_report"
             inherit_id="purchase_requisition.report_purchaserequisition_document">
             <xpath expr="//table[1]/thead/tr/th[1]" position="before">
                 <th name="th_d" class="text-start">No.</th>
@@ -88,7 +89,7 @@
                     <span t-field="line_ids.purchase_requistion_sequence" />
                 </td>
             </xpath>
-        </template>
+        </template> -->
 
     </data>
 </odoo>

--- a/external_addons/bi_order_line_with_sequence_number/views/order_line_view.xml
+++ b/external_addons/bi_order_line_with_sequence_number/views/order_line_view.xml
@@ -45,7 +45,8 @@
         </field>
     </record>
 
-    <record id="purchase_requistion_inherit_view" model="ir.ui.view">
+    <!-- # NOT USED -->
+    <!-- <record id="purchase_requistion_inherit_view" model="ir.ui.view">
         <field name="name">purchase.requisition.form.inherit</field>
         <field name="model">purchase.requisition</field>
         <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form"/>
@@ -54,7 +55,7 @@
                 <field name="purchase_requistion_sequence" groups="bi_order_line_with_sequence_number.access_display_order_line_number"/>
             </xpath>
         </field>
-    </record>
+    </record> -->
 
     <record id="stock_picking_inherit_view" model="ir.ui.view">
         <field name="name">stock.picking.form.inherit</field>


### PR DESCRIPTION
- due to unnecessary dependency
- remove all related code to the purchase requisition module