### PR TITLE
feat(sale order): handle duplicated pricelist item

### DIFF
--- a/addons/abp_pricelist/models/sale_order.py
+++ b/addons/abp_pricelist/models/sale_order.py
@@ -1,5 +1,6 @@
 from odoo import models, _
 from odoo.addons.abp_utils.utils import format_currency_amount
+from odoo.exceptions import ValidationError
 
 
 class SaleOrder(models.Model):
@@ -11,6 +12,11 @@ class SaleOrder(models.Model):
                 line._compute_pricelist_item_id()
     
     def button_print_barcode(self):
+        customer_product_refs = self.order_line.mapped('customer_product_ref')
+        barcode = self.order_line.mapped('barcode')
+        if 'Multiple pricelist item' in customer_product_refs or 'Multiple pricelist item' in barcode:
+            raise ValidationError(_('Duplicate items found on pricelist item. Remove duplicated items from pricelist item to continue'))
+        
         data = self._prepare_product_label_data(self)
         return self.env.ref('abp_pricelist.action_report_sales_product_barcode').report_action(self, data={'data': data})
     

--- a/addons/abp_pricelist/models/sale_order_line.py
+++ b/addons/abp_pricelist/models/sale_order_line.py
@@ -15,8 +15,17 @@ class SaleOrderLine(models.Model):
             super()._compute_pricelist_item_id()
             rec.customer_product_ref = rec.barcode = False
             rec.retail_price = 0.0
+            
             if rec.pricelist_item_id:
                 rec.customer_product_ref = rec.pricelist_item_id.customer_product_ref
                 rec.barcode = rec.pricelist_item_id.barcode
                 rec.retail_price = rec.pricelist_item_id.retail_price or rec.pricelist_item_id.fixed_price
                 
+            # Manually search to product.pricelist.item to make sure if there is only single pricelist item record
+            pricelist_item_temp = self.env['product.pricelist.item'].search([
+                ('pricelist_id', '=', rec.order_id.partner_id.property_product_pricelist.id),
+                ('product_tmpl_id', '=', rec.product_template_id.id)
+            ])
+            if len(pricelist_item_temp) > 1:
+                rec.customer_product_ref = rec.barcode = 'Multiple pricelist item'
+                rec.retail_price = 0.0


### PR DESCRIPTION
- fill customer product ref and barcode value with 'Multiple pricelist item'
- fill retail price with 0.0
- show validation error pop up if there is any duplicated pricelist item in the line when about to print the barcode